### PR TITLE
feat(shared-thematic) : autoriser le choix de plusieurs thématiques / feat(enquete-new) : suppression outils de dessin au step 3 & alerte si pas de forêt saisie lors du passage step 2 vers step 3

### DIFF
--- a/src/app/enquete/pages/enquete-new/enquete-new.component.html
+++ b/src/app/enquete/pages/enquete-new/enquete-new.component.html
@@ -16,7 +16,7 @@
 
   <div class="fr-grid-row fr-grid-row--gutters">
     <div class="fr-col-12 fr-col-lg-6">
-      <app-thematic-select *ngIf="step > 1" (select)="updateThematics($event)"></app-thematic-select>
+      <app-thematic-select *ngIf="step > 1" (select)="updateThematics()"></app-thematic-select>
     </div>
   </div>
 

--- a/src/app/enquete/pages/enquete-new/enquete-new.component.ts
+++ b/src/app/enquete/pages/enquete-new/enquete-new.component.ts
@@ -48,18 +48,32 @@ export class EnqueteNewComponent implements OnInit {
 
   nextStep() {
     this.step++;
+    switch(this.step) {
+      case 2:
+        if(!this.mapContextService.getLayerDessin().getSource().getFeatures().length) {
+          alert("Veuillez préciser le périmètre de votre forêt à l'aide des outils de dessins disponible sur la carte.");
+          this.step--;
+        }else {
+          this.mapContextService.removeDrawingTools();
+        };
+        return;
+    }
   }
 
 
   previousStep() {
     this.step--;
-    if (this.step == 0) {
-      this.mapContextService.resetDessin();
+    switch(this.step) {
+      case 0:
+        this.mapContextService.resetDessin();
+        return;
+      case 1:
+        this.mapContextService.addDrawingTools();
     }
   }
 
-  updateThematics(event: any) {
-    this.mapContextService.updateLayers(event.name);
+  updateThematics() {
+    this.mapContextService.updateLayers();
   }
 
 

--- a/src/app/shared-map/components/map-viewer/map-viewer.component.css
+++ b/src/app/shared-map/components/map-viewer/map-viewer.component.css
@@ -1,4 +1,5 @@
 #map {
   min-height: 600px;
+  max-height: 900px;
   height: 100%;
 }

--- a/src/app/shared-map/components/map-viewer/map-viewer.component.ts
+++ b/src/app/shared-map/components/map-viewer/map-viewer.component.ts
@@ -1,7 +1,4 @@
 import { Component, OnInit } from '@angular/core';
-import { Fill, Stroke, Style } from 'ol/style';
-import { Select } from 'ol/interaction';
-import EditBar from 'ol-ext/control/EditBar.js';
 
 import { MapContextService } from '../../services/map-context.service';
 
@@ -22,55 +19,8 @@ export class MapViewerComponent implements OnInit {
       return;
     }
 
-    this.mapContextService.map?.getView().setCenter([261271, 6249998]);
-    this.mapContextService.map?.getView().setZoom(13);
+    this.mapContextService.setView([261271, 6249998], 13);
+    this.mapContextService.addDrawingTools();
 
-    const style = new Style({
-      fill: new Fill({
-        color: 'rgba(73,73,232,0.4)',
-      }),
-      stroke: new Stroke({
-        color: '#3399CC'
-      })
-    });
-
-    if (!this.mapContextService.getLayerDessin()) {
-      return;
-    }
-    this.mapContextService.getLayerDessin()?.setStyle(style);
-
-    const selectStyle = new Style({
-      fill: new Fill({
-        color: 'rgba(255,40,48,0.4)',
-      }),
-      stroke: new Stroke({
-        color: '#F44336',
-        width: 4
-      })
-    });
-
-    const select = new Select({
-      layers: [this.mapContextService.getLayerDessin()],
-      style: selectStyle
-    });
-
-    const editBar = new EditBar({
-      interactions: {
-        Select: select,
-        Delete: true,
-        Info: false,
-        DrawPoint: false,
-        DrawLine: false,
-        DrawPolygon: true,
-        //@ts-ignore
-        DrawHole: true,
-        DrawRegular: false,
-        Transform: false,
-        Split: false,
-        Offset: false
-      },
-      source: this.mapContextService.getLayerDessin().getSource()
-    });
-    this.mapContextService.map?.addControl(editBar);
   }
 }

--- a/src/app/shared-map/models/map-layers-default.enum.ts
+++ b/src/app/shared-map/models/map-layers-default.enum.ts
@@ -1,20 +1,28 @@
 import GeoportailLayer from 'ol-ext/layer/Geoportail';
+import LayerGroup from 'ol/layer/Group';
 
 export const MAP_LAYERS_DEFAULT = [
-  new GeoportailLayer({
-    layer: 'ORTHOIMAGERY.ORTHOPHOTOS',
-    visible: false
-  }),
-  new GeoportailLayer({
-    layer: 'ADMINEXPRESS-COG-CARTO.LATEST',
-    visible: false
-  }),
-  new GeoportailLayer({
-    layer: 'CADASTRALPARCELS.PARCELLAIRE_EXPRESS',
-    visible: false
-  }),
-  new GeoportailLayer({
-    layer: 'GEOGRAPHICALGRIDSYSTEMS.PLANIGNV2',
-    visible: true
+  new LayerGroup({
+    //@ts-ignore
+    title: 'Fonds de carte',
+    group: 'base-layer',
+    layers: [
+      new GeoportailLayer({
+        layer: 'ORTHOIMAGERY.ORTHOPHOTOS',
+        visible: false
+      }),
+      new GeoportailLayer({
+        layer: 'ADMINEXPRESS-COG-CARTO.LATEST',
+        visible: false
+      }),
+      new GeoportailLayer({
+        layer: 'CADASTRALPARCELS.PARCELLAIRE_EXPRESS',
+        visible: false
+      }),
+      new GeoportailLayer({
+        layer: 'GEOGRAPHICALGRIDSYSTEMS.PLANIGNV2',
+        visible: true
+      })
+    ]
   })
 ];

--- a/src/app/shared-map/models/map-layers-default.enum.ts
+++ b/src/app/shared-map/models/map-layers-default.enum.ts
@@ -1,11 +1,12 @@
 import GeoportailLayer from 'ol-ext/layer/Geoportail';
 import LayerGroup from 'ol/layer/Group';
 
-export const MAP_LAYERS_DEFAULT = [
+export const MAP_DEFAULT_LAYER_GROUP =
   new LayerGroup({
-    //@ts-ignore
-    title: 'Fonds de carte',
-    group: 'base-layer',
+    
+    properties: {
+      title: 'Fonds de carte',
+      group: 'base-layer'},
     layers: [
       new GeoportailLayer({
         layer: 'ORTHOIMAGERY.ORTHOPHOTOS',
@@ -24,5 +25,4 @@ export const MAP_LAYERS_DEFAULT = [
         visible: true
       })
     ]
-  })
-];
+  });

--- a/src/app/shared-map/services/map-context.service.ts
+++ b/src/app/shared-map/services/map-context.service.ts
@@ -2,11 +2,14 @@ import { EventEmitter, Injectable } from '@angular/core';
 import Map from 'ol/Map.js';
 import View from 'ol/View.js';
 import LayerSwitcher from 'ol-ext/control/LayerSwitcher';
+import { Fill, Stroke, Style } from 'ol/style';
+import { Select } from 'ol/interaction';
+import EditBar from 'ol-ext/control/EditBar.js';
 import { MAP_LAYERS_DEFAULT } from '../models/map-layers-default.enum';
 import { MAP_BIODIVERISTE_LAYERS, MAP_MONUMENTS_LAYERS } from '../../shared-thematic/models/map-thematic-layers.enum';
 import VectorLayer from 'ol/layer/Vector';
 import { Vector } from 'ol/source';
-import LayerGroup from 'ol/layer/Group';
+import { THEMATICS } from '../../shared-thematic/models/thematic.enum';
 
 @Injectable({
   providedIn: 'root'
@@ -51,19 +54,99 @@ export class MapContextService {
     this.map.on('rendercomplete', (event) => this.mapLoaded.next(event));
   }
 
-  updateLayers(thematicName: string) {
-    const layers = this.map?.getAllLayers();
-    layers?.forEach((layer) => {
-      const group = layer.get('group') || 'base-layer';
-      if (group !== 'base-layer') {
-        this.map?.removeLayer(layer);
-      }
+  addDrawingTools() {
+    if (!this.getLayerDessin()) {
+      return;
+    }
+
+    const style = new Style({
+      fill: new Fill({
+        color: 'rgba(73,73,232,0.4)',
+      }),
+      stroke: new Stroke({
+        color: '#3399CC'
+      })
     });
+
+    
+    this.getLayerDessin().setStyle(style);
+
+    const selectStyle = new Style({
+      fill: new Fill({
+        color: 'rgba(255,40,48,0.4)',
+      }),
+      stroke: new Stroke({
+        color: '#F44336',
+        width: 4
+      })
+    });
+
+    const select = new Select({
+      layers: [this.getLayerDessin()],
+      style: selectStyle
+    });
+
+    const editBar = new EditBar({
+      interactions: {
+        Select: select,
+        Delete: true,
+        Info: false,
+        DrawPoint: false,
+        DrawLine: false,
+        DrawPolygon: true,
+        //@ts-ignore
+        DrawHole: true,
+        DrawRegular: false,
+        Transform: false,
+        Split: false,
+        Offset: false
+      },
+      source: this.getLayerDessin().getSource()
+    });
+    editBar.setProperties({name: "editBar"});
+    this.map?.addControl(editBar);
+  }
+
+  removeDrawingTools() {
+    let editBar: any;
+    this.map?.getControls().forEach((control) => {
+      if(control.get("name") == "editBar"){
+        editBar = control;
+      }
+    })
+
+    this.map?.removeControl(editBar);
+  };
+
+  updateLayers() {
+    const layers: any = this.map?.getLayers().getArray();
+    //utiliser "layers.forEach(...)" ne fonctionne pas
+    for(let i = layers.length-1; i > -1; i--) {
+      const group = layers[i].get('group') || 'base-layer';
+      if (group !== 'base-layer') {
+        this.map?.removeLayer(layers[i]);
+      }
+    }
 
     [...MAP_BIODIVERISTE_LAYERS, ...MAP_MONUMENTS_LAYERS].forEach((newlayer) => {
       const group = newlayer.get('group') || 'no-group';
-      if (group === thematicName) {
-        this.map?.addLayer(newlayer);
+      for(let i = 0; i < THEMATICS.length; i++) {
+        if(group === THEMATICS[i].name && THEMATICS[i].checked) {
+          this.map?.addLayer(newlayer);
+          continue;
+        }
+      }
+    });
+  }
+
+  updateLayersVisibility(event: any) {
+    const layers = this.map?.getLayers().getArray();
+    layers?.forEach((layer) => {
+      const group = layer.get('group') || 'base-layer';
+      if(group === 'base-layer' || group === event || event === 'synthese') {
+        layer.setVisible(true);
+      } else {
+        layer.setVisible(false);
       }
     });
   }

--- a/src/app/shared-map/services/map-context.service.ts
+++ b/src/app/shared-map/services/map-context.service.ts
@@ -5,8 +5,8 @@ import LayerSwitcher from 'ol-ext/control/LayerSwitcher';
 import { Fill, Stroke, Style } from 'ol/style';
 import { Select } from 'ol/interaction';
 import EditBar from 'ol-ext/control/EditBar.js';
-import { MAP_LAYERS_DEFAULT } from '../models/map-layers-default.enum';
-import { MAP_BIODIVERISTE_LAYERS, MAP_MONUMENTS_LAYERS } from '../../shared-thematic/models/map-thematic-layers.enum';
+import { MAP_DEFAULT_LAYER_GROUP } from '../models/map-layers-default.enum';
+import { MAP_BIODIVERISTE_LAYER_GROUP, MAP_MONUMENTS_LAYER_GROUP } from '../../shared-thematic/models/map-thematic-layers.enum';
 import VectorLayer from 'ol/layer/Vector';
 import { Vector } from 'ol/source';
 import { THEMATICS } from '../../shared-thematic/models/thematic.enum';
@@ -37,9 +37,9 @@ export class MapContextService {
         zoom: 1,
       }),
       layers: [
-        ...MAP_LAYERS_DEFAULT,
-        ...MAP_BIODIVERISTE_LAYERS,
-        ...MAP_MONUMENTS_LAYERS,
+        MAP_DEFAULT_LAYER_GROUP,
+        MAP_BIODIVERISTE_LAYER_GROUP,
+        MAP_MONUMENTS_LAYER_GROUP,
         new VectorLayer({
           source: new Vector(),
           properties: { title: 'Ma Forêt' },
@@ -128,7 +128,7 @@ export class MapContextService {
       }
     }
 
-    [...MAP_BIODIVERISTE_LAYERS, ...MAP_MONUMENTS_LAYERS].forEach((newlayer) => {
+    [MAP_BIODIVERISTE_LAYER_GROUP,MAP_MONUMENTS_LAYER_GROUP].forEach((newlayer) => {
       const group = newlayer.get('group') || 'no-group';
       for(let i = 0; i < THEMATICS.length; i++) {
         if(group === THEMATICS[i].name && THEMATICS[i].checked) {

--- a/src/app/shared-thematic/components/biodiversite/biodiversite.component.ts
+++ b/src/app/shared-thematic/components/biodiversite/biodiversite.component.ts
@@ -21,12 +21,8 @@ export class BiodiversiteComponent implements OnInit {
 
   ngOnInit(): void {
     const maForet = this.mapContextService.getMaForet();
-    // TODO trouver un moyen de tester l'abscence de foret dessiné sinon ça requete toutes les features
-    if (!maForet) {
-      return;
-    }
-    const observableRequest = MAP_BIODIVERISTE_LAYERS.map((layer)=> {
-      // PROTECTEDAREAS.ZPS:zps || PROTECTEDAREAS.ZNIEFF1:znieff1
+
+    const observableRequest = MAP_BIODIVERISTE_LAYERS[0].getLayersArray().map((layer)=> {
       return layer.get('technicalName');
     }).map((layername) => {
       return this.geoplateformeWfsService

--- a/src/app/shared-thematic/components/biodiversite/biodiversite.component.ts
+++ b/src/app/shared-thematic/components/biodiversite/biodiversite.component.ts
@@ -3,7 +3,7 @@ import { zip } from 'rxjs';
 
 import { MapContextService } from '../../../shared-map/services/map-context.service';
 import { GeoplateformeWfsService, LON_LAT_ORDER } from '../../services/geoplateforme-wfs.service';
-import { MAP_BIODIVERISTE_LAYERS } from '../../models/map-thematic-layers.enum';
+import { MAP_BIODIVERISTE_LAYER_GROUP } from '../../models/map-thematic-layers.enum';
 
 @Component({
   selector: 'app-biodiversite',
@@ -22,7 +22,7 @@ export class BiodiversiteComponent implements OnInit {
   ngOnInit(): void {
     const maForet = this.mapContextService.getMaForet();
 
-    const observableRequest = MAP_BIODIVERISTE_LAYERS[0].getLayersArray().map((layer)=> {
+    const observableRequest = MAP_BIODIVERISTE_LAYER_GROUP.getLayersArray().map((layer)=> {
       return layer.get('technicalName');
     }).map((layername) => {
       return this.geoplateformeWfsService

--- a/src/app/shared-thematic/components/monument-historique/monument-historique.component.ts
+++ b/src/app/shared-thematic/components/monument-historique/monument-historique.component.ts
@@ -21,10 +21,6 @@ export class MonumentHistoriqueComponent implements OnInit {
 
   ngOnInit(): void {
     const maForet = this.mapContextService.getMaForet();
-    // TODO trouver un moyen de tester l'abscence de foret dessiné sinon ça requete toutes les features
-    if (!maForet) {
-      return;
-    }
 
     const request = this.geoplateformeWfsService
       .buildRequest()

--- a/src/app/shared-thematic/components/thematic-select/thematic-select.component.html
+++ b/src/app/shared-thematic/components/thematic-select/thematic-select.component.html
@@ -1,4 +1,7 @@
 <div class="fr-mt-4v fr-mb-4v">
-  <dsfr-form-select label="Thématiques" hint="Vous pouvez sélectionner plusieurs thématiques." placeholder="Sélectionnez une thématique" [options]="options"
-    (selectChange)="selectChange($event)"></dsfr-form-select>
+  <dsfr-fieldset legend="Thématiques" hint="Vous pouvez sélectionner plusieurs thématiques." [inline]=true>
+    @for(cb of checkboxes; track cb) {
+      <dsfr-form-checkbox *fieldsetElement [label]="cb.label" [value]="cb.checked" (change)="onCheckboxChange($event)"></dsfr-form-checkbox>
+    }
+  </dsfr-fieldset>
 </div>

--- a/src/app/shared-thematic/components/thematic-select/thematic-select.component.ts
+++ b/src/app/shared-thematic/components/thematic-select/thematic-select.component.ts
@@ -11,32 +11,30 @@ export class ThematicSelectComponent implements OnInit {
 
   @Output() select: EventEmitter<any> = new EventEmitter<any>();
 
-  options: any[] = [];
+   checkboxes: any[] = [];
 
   constructor(
     private thematicSelectService: ThematicSelectService
   ) { }
 
   ngOnInit(): void {
-    this.optionsFromThematics();
-  }
+     this.checkboxes = THEMATICS.slice(1);
+  };
 
-  // Méthode appelée lors du changement de sélection
-  selectChange(event: any): void {
+  onCheckboxChange(event: any): void {
     if (!event) {
       return;
     }
-    this.thematicSelectService.updateSelectedThematic(event);
-    this.select.emit(event);
-  }
+    let label = event.target.labels[0].textContent;
 
-  private optionsFromThematics(): void {
-    this.options = THEMATICS.filter((theme) => theme.name !== 'synthese').map((theme) => {
-      return {
-        label: theme.label,
-        value: theme
-      };
-    });
-  }
+    for(let i = 0; i < THEMATICS.length; i++) {
+      if(THEMATICS[i].label == label) {
+        THEMATICS[i].checked = !THEMATICS[i].checked;
+      }
+    }
+
+    this.thematicSelectService.updateThematics(THEMATICS);
+    this.select.emit(event);
+  };
 
 }

--- a/src/app/shared-thematic/components/thematic-tabs/thematic-tabs.component.html
+++ b/src/app/shared-thematic/components/thematic-tabs/thematic-tabs.component.html
@@ -1,8 +1,8 @@
-<dsfr-tabs [selectedTabIndex]="selectedTabIndex">
+<dsfr-tabs [selectedTabIndex]="selectedTabIndex" (tabSelect)="selectTab($event)">
 
   @for (tab of tabsConfig; track $index) {
-  <dsfr-tab *ngIf="tab.active" [tabId]="tab.tabId" [label]="tab.label">
-    @switch (tab.tabId) {
+  <dsfr-tab *ngIf="tab.checked" [tabId]="tab.name" [label]="tab.label">
+    @switch (tab.name) {
     @case ('synthese') {
     <app-synthese></app-synthese>
     }

--- a/src/app/shared-thematic/components/thematic-tabs/thematic-tabs.component.spec.ts
+++ b/src/app/shared-thematic/components/thematic-tabs/thematic-tabs.component.spec.ts
@@ -6,6 +6,7 @@ import { AgricultureComponent } from '../agriculture/agriculture.component';
 import { BiodiversiteComponent } from '../biodiversite/biodiversite.component';
 import { EauComponent } from '../eau/eau.component';
 import { MonumentHistoriqueComponent } from '../monument-historique/monument-historique.component';
+import { appConfig } from '../../../app.config';
 
 
 describe('ThematicTabsComponent', () => {
@@ -15,7 +16,8 @@ describe('ThematicTabsComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [ThematicTabsComponent, SyntheseComponent, AgricultureComponent, BiodiversiteComponent, EauComponent, MonumentHistoriqueComponent],
-      imports: [SharedDesignDsfrModule]
+      imports: [SharedDesignDsfrModule],
+      providers: appConfig.providers
     })
     .compileComponents();
 

--- a/src/app/shared-thematic/components/thematic-tabs/thematic-tabs.component.ts
+++ b/src/app/shared-thematic/components/thematic-tabs/thematic-tabs.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { ThematicSelectService } from '../../services/thematic-select.service';
+import { MapContextService } from '../../../shared-map/services/map-context.service';
 import { THEMATICS } from '../../models/thematic.enum';
 
 @Component({
@@ -16,31 +17,35 @@ export class ThematicTabsComponent implements OnInit {
   selectedThematic: any = 0;
 
   constructor(
-    private thematicSelectService: ThematicSelectService
+    private thematicSelectService: ThematicSelectService,
+    private mapContextService: MapContextService
   ) { }
 
   ngOnInit() {
-    this.configFromThemes();
-    this.thematicSelectService.thematicSelection.subscribe((theme) => {
-      this.configFromThemes(theme);
+    this.tabsConfig = THEMATICS;
+    this.thematicSelectService.thematicSelection.subscribe(() => {
+      this.tabsConfig = THEMATICS;
+      if(!THEMATICS[this.selectedTabIndex].checked){
+        this.selectedTabIndex = 0;
+        this.selectTab("synthese");
+      }
     });
   }
 
-  private configFromThemes(selectTheme: any = null) {
-    this.tabsConfig = THEMATICS.map((theme: any) => {
-      let active = false;
-      if (theme.name === 'synthese') {
-        active = true;
+  selectTab(event: any) {
+    this.setSelectedTabIndex(event);
+    this.mapContextService.updateLayersVisibility(event);
+  }
+
+  setSelectedTabIndex(tabId: string) {
+    let indexModifier = 0;
+    for(let i = 0; i < THEMATICS.length; i++) {
+      if(THEMATICS[i].name === tabId) {
+        this.selectedTabIndex = i-indexModifier;
+      }else if(!THEMATICS[i].checked) {
+        indexModifier++;
       }
-      if (selectTheme && theme.name === selectTheme.name) {
-        active = true;
-      }
-      return {
-        tabId: theme.name,
-        label: theme.label,
-        active: active
-      };
-    });
+    }
   }
 
 }

--- a/src/app/shared-thematic/models/map-thematic-layers.enum.ts
+++ b/src/app/shared-thematic/models/map-thematic-layers.enum.ts
@@ -1,164 +1,179 @@
 import TileLayer from 'ol/layer/Tile';
 import { TileWMS } from 'ol/source';
+import LayerGroup from 'ol/layer/Group';
 
 export const MAP_BIODIVERISTE_LAYERS = [
-  new TileLayer({
-    properties: {
-      title: 'Natura 2000 Habitats',
-      group: 'biodiversite',
-      technicalName: 'PROTECTEDAREAS.SIC:sic'
-    },
-    extent: [
-      -20037508.342789244,
-      -44927335.42709704,
-      20037508.342789244,
-      44927335.42709663
-    ],
-    minResolution: 0,
-    maxResolution: 156543.03392804097,
-    source: new TileWMS({
-      url: 'https://data.geopf.fr/wms-r/ows?',
-      projection: 'EPSG:3857',
-      attributions: [],
-      crossOrigin: 'anonymous',
-      params: {
-        'LAYERS': 'PROTECTEDAREAS.SIC',
-        'FORMAT': 'image/png',
-        'VERSION': '1.3.0'
-      },
-    })
-  }),
-  new TileLayer({
-    properties: {
-      title: 'Natura 2000 Oiseaux',
-      group: 'biodiversite',
-      technicalName: 'PROTECTEDAREAS.ZPS:zps'
-    },
-    extent: [
-      -20037508.342789244,
-      -44927335.42709704,
-      20037508.342789244,
-      44927335.42709663
-    ],
-    minResolution: 0,
-    maxResolution: 156543.03392804097,
-    source: new TileWMS({
-      url: 'https://data.geopf.fr/wms-r/ows?',
-      projection: 'EPSG:3857',
-      attributions: [],
-      crossOrigin: 'anonymous',
-      params: {
-        'LAYERS': 'PROTECTEDAREAS.ZPS',
-        'FORMAT': 'image/png',
-        'VERSION': '1.3.0'
-      }
-    })
-  }),
-  new TileLayer({
-    properties: {
-      title: 'Prairies sensibles',
-      group: 'biodiversite',
-      technicalName: 'PRAIRIES.SENSIBLES.BCAE:prairies_sensibles'
-    },
-    extent: [
-      -20037508.342789244,
-      -44927335.42709704,
-      20037508.342789244,
-      44927335.42709663
-    ],
-    minResolution: 0,
-    maxResolution: 156543.03392804097,
-    source: new TileWMS({
-      url: 'https://data.geopf.fr/wms-r/ows?',
-      projection: 'EPSG:3857',
-      attributions: [],
-      crossOrigin: 'anonymous',
-      params: {
-        'LAYERS': 'PRAIRIES.SENSIBLES.BCAE',
-        'FORMAT': 'image/png',
-        'VERSION': '1.3.0'
-      }
-    })
-  }),
-  new TileLayer({
-    properties: {
-      title: 'ZNIEFF2',
-      group: 'biodiversite',
-      technicalName: 'PROTECTEDAREAS.ZNIEFF2:znieff2'
-    },
-    extent: [
-      -20037508.342789244,
-      -44927335.42709704,
-      20037508.342789244,
-      44927335.42709663
-    ],
-    minResolution: 0,
-    maxResolution: 156543.03392804097,
-    source: new TileWMS({
-      url: 'https://data.geopf.fr/wms-r/ows?',
-      projection: 'EPSG:3857',
-      attributions: [],
-      crossOrigin: 'anonymous',
-      params: {
-        'LAYERS': 'PROTECTEDAREAS.ZNIEFF2',
-        'FORMAT': 'image/png',
-        'VERSION': '1.3.0'
-      }
-    })
-  }),
-  new TileLayer({
-    properties: {
-      title: 'ZNIEFF1',
-      group: 'biodiversite',
-      technicalName: 'PROTECTEDAREAS.ZNIEFF1:znieff1'
-    },
-    extent: [
-      -20037508.342789244,
-      -44927335.42709704,
-      20037508.342789244,
-      44927335.42709663
-    ],
-    minResolution: 0,
-    maxResolution: 156543.03392804097,
-    source: new TileWMS({
-      url: 'https://data.geopf.fr/wms-r/ows?',
-      projection: 'EPSG:3857',
-      attributions: [],
-      crossOrigin: 'anonymous',
-      params: {
-        'LAYERS': 'PROTECTEDAREAS.ZNIEFF1',
-        'FORMAT': 'image/png',
-        'VERSION': '1.3.0'
-      }
-    })
+  new LayerGroup({
+    //@ts-ignore
+    title: 'Biodiversité',
+    group: 'biodiversite',
+    layers: [
+      new TileLayer({
+        properties: {
+          title: 'Natura 2000 Habitats',
+          group: 'biodiversite',
+          technicalName: 'PROTECTEDAREAS.SIC:sic'
+        },
+        extent: [
+          -20037508.342789244,
+          -44927335.42709704,
+          20037508.342789244,
+          44927335.42709663
+        ],
+        minResolution: 0,
+        maxResolution: 156543.03392804097,
+        source: new TileWMS({
+          url: 'https://data.geopf.fr/wms-r/ows?',
+          projection: 'EPSG:3857',
+          attributions: [],
+          crossOrigin: 'anonymous',
+          params: {
+            'LAYERS': 'PROTECTEDAREAS.SIC',
+            'FORMAT': 'image/png',
+            'VERSION': '1.3.0'
+          },
+        })
+      }),
+      new TileLayer({
+        properties: {
+          title: 'Natura 2000 Oiseaux',
+          group: 'biodiversite',
+          technicalName: 'PROTECTEDAREAS.ZPS:zps'
+        },
+        extent: [
+          -20037508.342789244,
+          -44927335.42709704,
+          20037508.342789244,
+          44927335.42709663
+        ],
+        minResolution: 0,
+        maxResolution: 156543.03392804097,
+        source: new TileWMS({
+          url: 'https://data.geopf.fr/wms-r/ows?',
+          projection: 'EPSG:3857',
+          attributions: [],
+          crossOrigin: 'anonymous',
+          params: {
+            'LAYERS': 'PROTECTEDAREAS.ZPS',
+            'FORMAT': 'image/png',
+            'VERSION': '1.3.0'
+          }
+        })
+      }),
+      new TileLayer({
+        properties: {
+          title: 'Prairies sensibles',
+          group: 'biodiversite',
+          technicalName: 'PRAIRIES.SENSIBLES.BCAE:prairies_sensibles'
+        },
+        extent: [
+          -20037508.342789244,
+          -44927335.42709704,
+          20037508.342789244,
+          44927335.42709663
+        ],
+        minResolution: 0,
+        maxResolution: 156543.03392804097,
+        source: new TileWMS({
+          url: 'https://data.geopf.fr/wms-r/ows?',
+          projection: 'EPSG:3857',
+          attributions: [],
+          crossOrigin: 'anonymous',
+          params: {
+            'LAYERS': 'PRAIRIES.SENSIBLES.BCAE',
+            'FORMAT': 'image/png',
+            'VERSION': '1.3.0'
+          }
+        })
+      }),
+      new TileLayer({
+        properties: {
+          title: 'ZNIEFF2',
+          group: 'biodiversite',
+          technicalName: 'PROTECTEDAREAS.ZNIEFF2:znieff2'
+        },
+        extent: [
+          -20037508.342789244,
+          -44927335.42709704,
+          20037508.342789244,
+          44927335.42709663
+        ],
+        minResolution: 0,
+        maxResolution: 156543.03392804097,
+        source: new TileWMS({
+          url: 'https://data.geopf.fr/wms-r/ows?',
+          projection: 'EPSG:3857',
+          attributions: [],
+          crossOrigin: 'anonymous',
+          params: {
+            'LAYERS': 'PROTECTEDAREAS.ZNIEFF2',
+            'FORMAT': 'image/png',
+            'VERSION': '1.3.0'
+          }
+        })
+      }),
+      new TileLayer({
+        properties: {
+          title: 'ZNIEFF1',
+          group: 'biodiversite',
+          technicalName: 'PROTECTEDAREAS.ZNIEFF1:znieff1'
+        },
+        extent: [
+          -20037508.342789244,
+          -44927335.42709704,
+          20037508.342789244,
+          44927335.42709663
+        ],
+        minResolution: 0,
+        maxResolution: 156543.03392804097,
+        source: new TileWMS({
+          url: 'https://data.geopf.fr/wms-r/ows?',
+          projection: 'EPSG:3857',
+          attributions: [],
+          crossOrigin: 'anonymous',
+          params: {
+            'LAYERS': 'PROTECTEDAREAS.ZNIEFF1',
+            'FORMAT': 'image/png',
+            'VERSION': '1.3.0'
+          }
+        })
+      })
+    ]
   })
 ];
 
 export const MAP_MONUMENTS_LAYERS = [
-  new TileLayer({
-    properties: {
-      title: 'Monuments historiques',
-      group: 'monument-historique',
-      technicalName: 'monument_historique'
-    },
-    extent: [
-      -20037508.342789244,
-      -44927335.42709704,
-      20037508.342789244,
-      44927335.42709663
-    ],
-    minResolution: 0,
-    maxResolution: 156543.03392804097,
-    source: new TileWMS({
-      url: 'https://data.geopf.fr/wms-v/ows?',
-      projection: 'EPSG:3857',
-      attributions: [],
-      crossOrigin: 'anonymous',
-      params: {
-        'LAYERS': 'monument_historique',
-        'FORMAT': 'image/png',
-        'VERSION': '1.3.0'
-      }
-    })
+  new LayerGroup({
+    //@ts-ignore
+    title: 'Monument Historique',
+    group: 'monument-historique',
+    layers: [
+      new TileLayer({
+        properties: {
+          title: 'Monuments historiques',
+          group: 'monument-historique',
+          technicalName: 'monument_historique'
+        },
+        extent: [
+          -20037508.342789244,
+          -44927335.42709704,
+          20037508.342789244,
+          44927335.42709663
+        ],
+        minResolution: 0,
+        maxResolution: 156543.03392804097,
+        source: new TileWMS({
+          url: 'https://data.geopf.fr/wms-v/ows?',
+          projection: 'EPSG:3857',
+          attributions: [],
+          crossOrigin: 'anonymous',
+          params: {
+            'LAYERS': 'monument_historique',
+            'FORMAT': 'image/png',
+            'VERSION': '1.3.0'
+          }
+        })
+      })
+    ]
   })
 ];

--- a/src/app/shared-thematic/models/map-thematic-layers.enum.ts
+++ b/src/app/shared-thematic/models/map-thematic-layers.enum.ts
@@ -2,11 +2,12 @@ import TileLayer from 'ol/layer/Tile';
 import { TileWMS } from 'ol/source';
 import LayerGroup from 'ol/layer/Group';
 
-export const MAP_BIODIVERISTE_LAYERS = [
+export const MAP_BIODIVERISTE_LAYER_GROUP = 
   new LayerGroup({
-    //@ts-ignore
-    title: 'Biodiversité',
-    group: 'biodiversite',
+    properties: {
+      title: 'Biodiversité',
+      group: 'biodiversite'
+    },
     layers: [
       new TileLayer({
         properties: {
@@ -139,10 +140,9 @@ export const MAP_BIODIVERISTE_LAYERS = [
         })
       })
     ]
-  })
-];
+  });
 
-export const MAP_MONUMENTS_LAYERS = [
+export const MAP_MONUMENTS_LAYER_GROUP = 
   new LayerGroup({
     //@ts-ignore
     title: 'Monument Historique',
@@ -175,5 +175,4 @@ export const MAP_MONUMENTS_LAYERS = [
         })
       })
     ]
-  })
-];
+  });

--- a/src/app/shared-thematic/models/thematic.enum.ts
+++ b/src/app/shared-thematic/models/thematic.enum.ts
@@ -1,7 +1,7 @@
 export const THEMATICS = [
-  { name: 'synthese', label: 'Synthèse' },
-  { name: 'agriculture', label: 'Agriculture' },
-  { name: 'biodiversite', label: 'Biodiversité' },
-  { name: 'eau', label: 'Eau' },
-  { name: 'monument-historique', label: 'Monument Historique' }
+  { name: 'synthese', label: 'Synthèse', checked: true },
+  //{ name: 'agriculture', label: 'Agriculture', checked: true },
+  { name: 'biodiversite', label: 'Biodiversité', checked: true },
+  //{ name: 'eau', label: 'Eau', checked: true },
+  { name: 'monument-historique', label: 'Monument Historique', checked: true }
 ];

--- a/src/app/shared-thematic/services/geoplateforme-wfs.service.ts
+++ b/src/app/shared-thematic/services/geoplateforme-wfs.service.ts
@@ -49,7 +49,6 @@ export class GeoplateformeWfsService {
   }
 
   intersectCollection(features: any[], geometryName: string = GEOMETRY_NAME, lonLatOrder: boolean = LON_LAT_ORDER): GeoplateformeWfsService {
-    // const intersectFilter = 'INTERSECTS(the_geom, MULTIPOLYGON(((48.83555415770596 2.4272448684002867, 48.828209180338774 2.4310214186932555, 48.83306828591324 2.4629504348065367, 48.84312400742064 2.4552256728436457, 48.83555415770596 2.4272448684002867, 48.83555415770596 2.4272448684002867))))';
     const intersectFilter = this.getIntersectsFilter(geometryName, features, lonLatOrder);
     if (intersectFilter !== '') {
       this.request.cqlFilters.push(intersectFilter);

--- a/src/app/shared-thematic/services/thematic-select.service.ts
+++ b/src/app/shared-thematic/services/thematic-select.service.ts
@@ -9,8 +9,8 @@ export class ThematicSelectService {
 
   constructor() {}
 
-  updateSelectedThematic(thematic: any) {
-    this.thematicSelection.next(thematic);
+  updateThematics(thematics: any) {
+    this.thematicSelection.next(thematics);
   }
 
 }


### PR DESCRIPTION
**shared-thematic** : 
- Layers organisés en layerGroup
- Thématiques visibles dans la table sélectionnées via checkbox:
    - La constante `THEMATICS` est utilisée pour tracer le statut des checkbox (`Agriculture` et `Eau` mises en commentaires car pas de données sur ces thématiques pour l'instant)
    - Décocher une checkbox enlève le layerGroup du thème dans la carte, cocher une checkbox ajoute le layerGroup du thème dans la carte
- Sélectionner l'onglet d'une thématique masque (mais n'enlève pas) les layerGroup de toutes les autres thématiques (sauf pour l'onglet "Synthèse" : tous les layerGroup sont visibles)

**enquete-new :** 
- Impossible de passer au step 3 si l'utilisateur n'a pas délimité une forêt dans le step 2 (message d'alerte le cas échéant)
- Les outils de dessin sont enlévés au step 3 (et remis si on revient au step précédent)