### PR TITLE
feat(shared-thematic) : gestion de l'affichage de certaines couches en fonction du niveau de zoom

### DIFF
--- a/src/app/shared-thematic/models/map-thematic-layers.enum.ts
+++ b/src/app/shared-thematic/models/map-thematic-layers.enum.ts
@@ -127,6 +127,7 @@ export const MAP_BIODIVERISTE_LAYER_GROUP = new LayerGroup({
         20037508.342789244,
         44927335.42709663
       ],
+      minZoom: 12,
       minResolution: 0,
       maxResolution: 156543.03392804097,
       source: new TileWMS({
@@ -422,6 +423,7 @@ export const MAP_PATRIMOINE_LAYER_GROUP = new LayerGroup({
         20037508.342789244,
         44927335.42709663
       ],
+      minZoom: 11.5,
       minResolution: 0,
       maxResolution: 156543.03392804097,
       source: new TileWMS({
@@ -445,6 +447,7 @@ export const MAP_PATRIMOINE_LAYER_GROUP = new LayerGroup({
         20037508.342789244,
         44927335.42709663
       ],
+      minZoom: 15.5,
       minResolution: 0,
       maxResolution: 156543.03392804097,
       source: new TileWMS({


### PR DESCRIPTION
Je sais pas si ça vaut le coup de faire une PR pour l'ajout de trois `minZoom` mais par principe, je le fais quand même.

À noter que la couche PROTECTEDAREAS.APLG:aplg (Arrêtés listes de sites d'intérêt géologique) affiche une grosse mosaïque blanche sur une bonne partie de la France, du coup je lui ai mis un `minZoom` pour limiter l'impact.

Si validation, l'[issue 33](https://github.com/IGNF/geoportail-environnement.beta.gouv.fr/issues/33) peut être fermée.