### PR TITLE
feat(shared-reglementation) : affichage de la reglementation en fonct…

### DIFF
--- a/src/app/shared-reglementation/components/reglementation-view/reglementation-view.component.html
+++ b/src/app/shared-reglementation/components/reglementation-view/reglementation-view.component.html
@@ -1,17 +1,20 @@
 @if (reglementation) {
+
 <div [innerHTML]="reglementation.description"></div>
 <div [innerHTML]="reglementation.impactReglementaire"></div>
 <div [innerHTML]="reglementation.impactProcedure"></div>
-  @if(reglementation.referenceUrl){
-    <p>
-      <a [href]="reglementation.referenceUrl">Accès référence réglementaire</a>
-    </p>
-  }
-  @if(reglementation.contact) {
-    <p>
-      Point de contact : {{ reglementation.contact }}.
-    </p>
-  }
+
+@if(reglementation.referenceUrl){
+<p>
+  <a [href]="reglementation.referenceUrl" target="_blank">Consulter la référence réglementaire</a>
+</p>
+}
+@if(reglementation.contact) {
+<p>
+  Pour vos procédures vueillez contacter <b>{{ reglementation.contact }}</b>.
+</p>
+}
+
 } @else {
 <p>Aucune reglementation ou recommandation.</p>
 }

--- a/src/app/shared-reglementation/components/reglementation-view/reglementation-view.component.html
+++ b/src/app/shared-reglementation/components/reglementation-view/reglementation-view.component.html
@@ -2,12 +2,16 @@
 <div [innerHTML]="reglementation.description"></div>
 <div [innerHTML]="reglementation.impactReglementaire"></div>
 <div [innerHTML]="reglementation.impactProcedure"></div>
-<p>
-  <a [href]="reglementation.referenceUrl">Accès référence réglementaire</a>
-</p>
-<p>
-  Point de concat {{ reglementation.contact }}.
-</p>
+  @if(reglementation.referenceUrl){
+    <p>
+      <a [href]="reglementation.referenceUrl">Accès référence réglementaire</a>
+    </p>
+  }
+  @if(reglementation.contact) {
+    <p>
+      Point de contact : {{ reglementation.contact }}.
+    </p>
+  }
 } @else {
 <p>Aucune reglementation ou recommandation.</p>
 }

--- a/src/app/shared-reglementation/components/reglementation-view/reglementation-view.component.ts
+++ b/src/app/shared-reglementation/components/reglementation-view/reglementation-view.component.ts
@@ -17,9 +17,8 @@ export class ReglementationViewComponent implements OnInit {
 
   ngOnInit() {
     if (!this.reglementation) {
-      this.reglementation = REGLEMENTATION_LIST[0];
+      this.reglementation = REGLEMENTATION_LIST.filter(reglement => reglement.layerName === this.layerReference)[0];
     }
-    // todo rechercher reglementation par reference
   }
 
 }

--- a/src/app/shared-reglementation/components/reglementation-view/reglementation-view.component.ts
+++ b/src/app/shared-reglementation/components/reglementation-view/reglementation-view.component.ts
@@ -13,11 +13,11 @@ export class ReglementationViewComponent implements OnInit {
 
   @Input() reglementation?: Reglementation;
 
-  constructor() {}
+  constructor() { }
 
   ngOnInit() {
     if (!this.reglementation) {
-      this.reglementation = REGLEMENTATION_LIST.filter(reglement => reglement.layerName === this.layerReference)[0];
+      this.reglementation = REGLEMENTATION_LIST.find(reglement => reglement.layerName === this.layerReference);
     }
   }
 

--- a/src/app/shared-reglementation/models/reglementation-list.enum.ts
+++ b/src/app/shared-reglementation/models/reglementation-list.enum.ts
@@ -3,7 +3,7 @@ import { Reglementation } from './reglementation.model';
 export const REGLEMENTATION_LIST = [
   new Reglementation().deserialise({
     thematicName: 'Biodiversité',
-    layerName: 'TODO',
+    layerName: 'Natura 2000 Habitats',
     title: 'Sites Natura 2000 au titre de la Directive Habitats',
     description: '<p>Espace désigné à l\'échelle européenne pour  la rareté ou la fragilité des habitats et des espèces animales et végétales qu’il abrite.</p>',
     impactReglementaire: '<p>Les créations de voies forestières, de places de dépôt de bois et les premiers boisements sont susceptibles d\'être soumis à une évaluation des incidences.</p><p>Elle doit également être réalisée pour tous autres travaux (notamment les coupes), s\'ils sont soumis à une autorisation administrative.</p>',
@@ -13,12 +13,202 @@ export const REGLEMENTATION_LIST = [
   }),
   new Reglementation().deserialise({
     thematicName: 'Biodiversité',
-    layerName: 'TODO',
-    title: 'Sites Natura 2000 au titre de la Directive Habitats',
-    description: '<p>Espace désigné à l\'échelle européenne pour  la rareté ou la fragilité des habitats et des espèces animales et végétales qu’il abrite.</p>',
-    impactReglementaire: '<p>Les créations de voies forestières, de places de dépôt de bois et les premiers boisements sont susceptibles d\'être soumis à une évaluation des incidences.</p><p>Elle doit également être réalisée pour tous autres travaux (notamment les coupes), s\'ils sont soumis à une autorisation administrative.</p>',
+    layerName: 'Natura 2000 Oiseaux',
+    title: 'Sites Natura 2000 au titre de la Directive Oiseaux',
+    description: '<p>Espace désigné à l\'échelle européenne pour son intérêt dans la reproduction, de migration et d\'hivernage d\'espèces d\'oiseaux.</p>',
+    impactReglementaire: '<p>Les créations de voies forestières, de places de dépôt de bois et les premiers boisements d’une surface supérieure à 1 ha,  doivent faire l\'objet d\'une une évaluation des incidences.</p><p> Elle doit également être réalisée pour tous autres travaux (notamment les coupes), s\'ils sont soumis à une autorisation administrative.</p>',
     impactProcedure: '<p>L\'évaluation des incidences a pour but de déterminer si le projet peut avoir un impact significatif sur les habitats, les espèces végétales et les espèces animales ayant justifié la désignation du site Natura 2000. </p>',
     referenceUrl: 'https://www.natura2000.fr/',
     contact: 'Direction départementale des territoires'
+  }),
+  new Reglementation().deserialise({
+    thematicName: 'Biodiversité',
+    layerName: 'Coeurs de parcs nationaux',
+    title: 'Coeurs de parcs nationaux',
+    description: '<p>Un parc national est un territoire reconnu comme exceptionnel par la richesse de sa biodiversité, la qualité de ses paysages et de son patrimoine culturel. Le cœur bénéficie d\'un statut de protection.</p>',
+    impactReglementaire: '<p>Une réglementation spécifique à chaque parc national, encadre la bonne pratique des activités humaines dans le cœur afin qu\'elles aient le moins d\'impacts possibles sur les milieux naturels et la biodiversité.</p>',
+    impactProcedure: '<p>La circulation, les travaux, l\'exploitation forestière sont généralement règlementés. Avant toute intervention, consulter l\'équipe du parc national.</p>',
+    referenceUrl: 'https://www.parcsnationaux.fr/fr/des-decouvertes/les-parcs-nationaux-de-france/reglementation-dans-les-parcs-nationaux-de-France',
+    contact: 'Parc national concerné'
+  }),
+  new Reglementation().deserialise({
+    thematicName: 'Biodiversité',
+    layerName: 'Zones d\'adhésion de parcs nationaux',
+    title: 'Zones d\'adhésion de parcs nationaux',
+    description: '<p>Un parc national est un territoire reconnu comme exceptionnel par la richesse de sa biodiversité, la qualité de ses paysages et de son patrimoine culturel.</p>',
+    impactReglementaire: '<p>Sauf décision locale particulière, cette zone du Parc national n\'est pas soumise à une réglementation environnementale particulière.</p>',
+    impactProcedure: '<p>Ce zonage n\'implique pas de formalité particulière.</p>',
+    referenceUrl: '',
+    contact: ''
+  }),
+  new Reglementation().deserialise({
+    thematicName: 'Biodiversité',
+    layerName: 'Arrêtés de protection de géotope',
+    title: 'Arrêtés de protection de géotope',
+    description: '<p>Les arrêtés de protection de géotope visent à protéger des sites géologiques.</p>',
+    impactReglementaire: '<p>Une règlementation spécifique à chaque espace est applicable.</p>',
+    impactProcedure: '<p>La gestion forestière courante n\'est généralement pas impactée si elle ne porte pas atteinte aux éléments géologiques.</p>',
+    referenceUrl: '',
+    contact: 'Direction départementale des territoires'
+  }),
+  new Reglementation().deserialise({
+    thematicName: 'Biodiversité',
+    layerName: 'Arrêtés de protection d\'habitats naturels',
+    title: 'Arrêtés de protection d\'habitats naturels',
+    description: '<p>Les APHN sont des arrêtés visant à préserver des habitats naturels présentant un intérêt particulier à titre scientifique, de rôle essentiel dans l\'écosystème ou de la préservation du patrimoine naturel.</p>',
+    impactReglementaire: '<p>Une règlementation spécifique à chaque espace est applicable.</p>',
+    impactProcedure: '<p>Les activités forestières peuvent être règlementées. La présence d"habitats naturels patrimoniaux nécessite une grande prudence avant tous travaux ou exploitation.</p>',
+    referenceUrl: '',
+    contact: 'Direction départementale des territoires'
+  }),
+  new Reglementation().deserialise({
+    thematicName: 'Biodiversité',
+    layerName: 'Biotopes d\'espèces protégées',
+    title: 'Arrêtés de protection de biotope',
+    description: '<p>Les arrêtés de protection de biotope visent à protéger les habitats nécessaires à l\'alimentation, à la reproduction, au repos ou à la survie d\'espèces protégées. Il concernent souvent des milieux très remarques, sur des surfaces limitées.</p>',
+    impactReglementaire: '<p>Une règlementation spécifique à chaque espace est applicable.</p>',
+    impactProcedure: '<p>Les activités forestières peuvent être règlementées. La présence probable d\'espèces protégées nécessite une grande prudence avant tous travaux ou exploitation.</p>',
+    referenceUrl: '',
+    contact: 'Direction départementale des territoires'
+  }),
+  new Reglementation().deserialise({
+    thematicName: 'Biodiversité',
+    layerName: 'Réserves Naturelles de Corse',
+    title: 'Réserves naturelles de Corse',
+    description: '<p>Une réserve naturelle est un site naturel fragile protégé par une réglementation adaptée et une gestion locale planifiée et concertée.</p>',
+    impactReglementaire: '<p>Les travaux, la circulation et les activités forestières peuvent faire l\'objet d\'une règlementation, adaptée à chaque réserve.</p>',
+    impactProcedure: '',
+    referenceUrl: '',
+    contact: 'Le gestionnaire de la réserve'
+  }),
+  new Reglementation().deserialise({
+    thematicName: 'Biodiversité',
+    layerName: 'Réserves naturelles nationales',
+    title: 'Réserves naturelles nationales',
+    description: '<p>Une réserve naturelle est un site naturel fragile protégé par une réglementation adaptée et une gestion locale planifiée et concertée.</p>',
+    impactReglementaire: '<p>Les travaux, la circulation et les activités forestières peuvent faire l\'objet d\'une règlementation, adaptée à chaque réserve.</p>',
+    impactProcedure: '',
+    referenceUrl: '',
+    contact: 'Le gestionnaire de la réserve'
+  }),
+  new Reglementation().deserialise({
+    thematicName: 'Biodiversité',
+    layerName: 'Réserves naturelles régionales',
+    title: 'Réserves naturelles régionales',
+    description: '<p>Une réserve naturelle est un site naturel fragile protégé par une réglementation adaptée et une gestion locale planifiée et concertée.</p>',
+    impactReglementaire: '<p>Les travaux, la circulation et les activités forestières peuvent faire l\'objet d\'une règlementation, adaptée à chaque réserve.</p>',
+    impactProcedure: '',
+    referenceUrl: '',
+    contact: 'Le gestionnaire de la réserve'
+  }),
+  new Reglementation().deserialise({
+    thematicName: 'Biodiversité',
+    layerName: 'Périmètres de protection de réserves naturelles',
+    title: 'Périmètres de protection de réserves naturelles',
+    description: '',
+    impactReglementaire: '',
+    impactProcedure: '',
+    referenceUrl: '',
+    contact: ''
+  }),
+  new Reglementation().deserialise({
+    thematicName: 'Biodiversité',
+    layerName: 'Arrêtés listes de sites d\'intérêt géologique',
+    title: 'Arrêtés de listes de sites d\'intérêt géologique',
+    description: '',
+    impactReglementaire: '',
+    impactProcedure: '',
+    referenceUrl: '',
+    contact: ''
+  }),
+  new Reglementation().deserialise({
+    thematicName: 'Biodiversité',
+    layerName: 'Réserves Biologiques',
+    title: 'Réserves biologiques',
+    description: '',
+    impactReglementaire: '',
+    impactProcedure: '',
+    referenceUrl: '',
+    contact: ''
+  }),
+  new Reglementation().deserialise({
+    thematicName: 'Biodiversité',
+    layerName: 'Réserves nationales de chasse et de faune sauvage',
+    title: 'Réserves nationales de chasse et de faune sauvage',
+    description: '',
+    impactReglementaire: '',
+    impactProcedure: '',
+    referenceUrl: '',
+    contact: ''
+  }),
+  new Reglementation().deserialise({
+    thematicName: 'Biodiversité',
+    layerName: 'Parcs naturels régionaux',
+    title: 'Parcs naturels régionaux',
+    description: '<p>Territoire créé pour protéger et mettre en valeur de grands espaces ruraux habités, notamment les  richesses naturelles, culturelles et humaines (traditions populaires, savoir-faire techniques).</p>',
+    impactReglementaire: '<p>Le droit commun est le même dans le territoire du parc naturel régional qu\'ailleurs. Il n\'a pas d\'impact règlementaire spécifique pour les travaux forestiers.</p>',
+    impactProcedure: '<p>Ce zonage n\'implique pas de formalité particulière.</p>',
+    referenceUrl: '',
+    contact: ''
+  }),
+  new Reglementation().deserialise({
+    thematicName: 'Biodiversité',
+    layerName: 'Conservatoire du littoral - sites sous responsabilité du conservatoire',
+    title: 'Conservatoire du littoral - sites sous responsabilité du conservatoire',
+    description: '',
+    impactReglementaire: '',
+    impactProcedure: '',
+    referenceUrl: '',
+    contact: ''
+  }),
+  new Reglementation().deserialise({
+    thematicName: 'Biodiversité',
+    layerName: 'Terrains des conservatoires d\'espaces naturels',
+    title: 'Conservatoires d\'espaces naturels',
+    description: '',
+    impactReglementaire: '',
+    impactProcedure: '',
+    referenceUrl: '',
+    contact: ''
+  }),
+  new Reglementation().deserialise({
+    thematicName: 'Biodiversité',
+    layerName: 'ZNIEFF1',
+    title: 'Zones naturelles d\'interet ecologique faunistique et floristique (ZNIEFF) type I',
+    description: '<p>Zone présentant une richesse biologique intéressante (faune et flore), reconnue d\'un grand intérêt pour le fonctionnement biologique local.</p>',
+    impactReglementaire: '<p>Inventaire informatif ne générant pas de contraintes règlementaires. Cependant ce zonage traduit la possible présence d\'espèces animales et végétales remarquables pouvant faire l\'objet d\'un dispositif de protection.</p>',
+    impactProcedure: '<p>A prendre en compte lors de la planification de la gestion ou en cas de réalisation de travaux, notamment si le terrain présente des milieux spécifiques comme des tourbières, des mares, des cours d\'eau etc.</p>',
+    referenceUrl: '',
+    contact: ''
+  }),
+  new Reglementation().deserialise({
+    thematicName: 'Biodiversité',
+    layerName: 'ZNIEFF2',
+    title: 'Zones naturelles d\'interet ecologique faunistique et floristique (ZNIEFF) type II',
+    description: '<p>Zone présentant des ensembles naturels et paysagers avec une cohésion élevée et plus riches que les milieux alentours.</p>',
+    impactReglementaire: '<p>Inventaire informatif ne générant pas de contraintes règlementaires. Cependant ce zonage traduit la possible présence d\'espèces animales et végétales remarquables pouvant faire l\'objet d\'un dispositif de protection.</p>',
+    impactProcedure: '<p>A prendre en compte lors de la planification de la gestion ou en cas de réalisation de travaux, notamment si le terrain présente des milieux spécifiques comme des tourbières, des mares, des cours d\'eau etc.</p>',
+    referenceUrl: '',
+    contact: ''
+  }),
+  new Reglementation().deserialise({
+    thematicName: 'Patrimoine',
+    layerName: 'Monuments historiques',
+    title: 'Protection des abords des monuments historiques ( Périmètre délimité des abords ou abords de 500m)',
+    description: '<p>Un monument historique classé est un immeuble protégé pour son intérêt  notamment du point de vue artistique, historique, scientifique,légendaire ou pittoresque. Aux abords de ce monument, un périmètre de protecion est destiné à garantir le caractère paysager des abords.</p>',
+    impactReglementaire: '<p>Les travaux susceptibles de modifier le paysage aux abords des monuments historiques sont sous à autorisation. C\'est le cas notamment des coupes ou des créations de voiries forestière.</p>',
+    impactProcedure: '<p>Si les travaux se situent également en site classé ou nécessitent une autre autorisation (se rapprocher de la DDT), l\'architecte des bâtiments de France sera consulté par le service qui instruira l\'autorisation.</p><p> Sinon, une demande d\'autorisation est à déposer en mairie. Il ets recommandé de contacter auparant l\'UDAP pour avoir son avis.</p>',
+    referenceUrl: '',
+    contact: 'UDAP du département'
+  }),
+  new Reglementation().deserialise({
+    thematicName: 'Patrimoine',
+    layerName: 'Espaces boisés classés',
+    title: 'Espaces boisés classés au PLU au titre du  L.113-1 CU',
+    description: '<p>Les espaces boisés classés  à conserver, à protéger ou à créer sont définis dans le plan local d\'urbanisme de la commune. Ils sont destinés à maintenir le paysage, réaliser des coulées vertes, protéger contre les risques naturels etc. </p>',
+    impactReglementaire: '<p>Les terrains ne peuvent changer d\'affectation : ils doivent rester forestier. Il ne peut donc y avoir de défrichement. Les coupes qui ne sont pas prévues dans un plan simple de gestion doivent faire l\'objet d\'une déclaration préalable.</p>',
+    impactProcedure: '<p>La déclaration de coupe est à envoyer en mairie du lieu de la coupe, à l\'aide du formulaire Cerfa n° 13404 en cochant "Coupe et abattage d\'arbres" en page 4.</p>',
+    referenceUrl: 'https://www.service-public.fr/particuliers/vosdroits/R11646',
+    contact: 'Mairie de la commune de situation'
   }),
 ];

--- a/src/app/shared-thematic/components/layer-fiche-view/layer-fiche-view.component.html
+++ b/src/app/shared-thematic/components/layer-fiche-view/layer-fiche-view.component.html
@@ -2,6 +2,8 @@
 
 <h4 class="fr-h6">{{ layer.title }}</h4>
 
+<app-reglementation-view [layerReference]="layer.title"></app-reglementation-view>
+
 @if (displaySituationMap) {
   <app-map-viewer [id]="map" [situationMap]="displaySituationMap"></app-map-viewer>
 }
@@ -18,7 +20,6 @@
 
   }
 </ul>
-
-<app-reglementation-view [layerReference]="layer.title"></app-reglementation-view>
+<br>
 
 }

--- a/src/app/shared-thematic/components/layer-fiche-view/layer-fiche-view.component.html
+++ b/src/app/shared-thematic/components/layer-fiche-view/layer-fiche-view.component.html
@@ -5,7 +5,7 @@
 <app-reglementation-view [layerReference]="layer.title"></app-reglementation-view>
 
 @if (displaySituationMap) {
-  <app-map-viewer [id]="map" [situationMap]="displaySituationMap"></app-map-viewer>
+<app-map-viewer [id]="map" [situationMap]="displaySituationMap"></app-map-viewer>
 }
 
 <ul>
@@ -20,6 +20,11 @@
 
   }
 </ul>
-<br>
+
+<!-- <dsfr-tags-group>
+  @for (feature of layer.features; track feature) {
+  <dsfr-tag [label]="feature.name" [route]="" (click)="openTab(feature.link)"></dsfr-tag>
+  }
+</dsfr-tags-group> -->
 
 }

--- a/src/app/shared-thematic/components/layer-fiche-view/layer-fiche-view.component.ts
+++ b/src/app/shared-thematic/components/layer-fiche-view/layer-fiche-view.component.ts
@@ -21,6 +21,11 @@ export class LayerInfoViewComponent implements OnChanges {
     this.prepareMap();
   }
 
+  openTab(link: string) {
+    const windowReference: any = window;
+    windowReference.open(link, '_blank').focus();
+  }
+
   private prepareMap() {
     if (this.layer && this.displaySituationMap) {
       this.map = this.layer.technicalName;

--- a/src/app/shared-thematic/components/thematic-list/thematic-list.component.ts
+++ b/src/app/shared-thematic/components/thematic-list/thematic-list.component.ts
@@ -101,8 +101,13 @@ export class ThematicListComponent {
       const layer = features[i].layer;
       switch (layer) {
         case 'assiette_sup_s':
-          if (!this.mapContextService.getActiveThematicLayers().includes({ theme: 'monument_historique', name: "assiette_sup_s" })) {
-            this.mapContextService.getActiveThematicLayers().push({ theme: 'monument_historique', name: "assiette_sup_s" });
+          if (!this.mapContextService.getActiveThematicLayers().includes({ theme: 'patrimoine', name: "assiette_sup_s" })) {
+            this.mapContextService.getActiveThematicLayers().push({ theme: 'patrimoine', name: "assiette_sup_s" });
+          }
+          break;
+        case 'prescription_surf':
+          if (!this.mapContextService.getActiveThematicLayers().includes({ theme: 'patrimoine', name: "prescription_surf" })) {
+            this.mapContextService.getActiveThematicLayers().push({ theme: 'patrimoine', name: "prescription_surf" });
           }
           break;
         default:

--- a/src/app/shared-thematic/components/thematic-tabs/thematic-tabs.component.html
+++ b/src/app/shared-thematic/components/thematic-tabs/thematic-tabs.component.html
@@ -1,17 +1,17 @@
 <dsfr-tabs [selectedTabIndex]="selectedTabIndex" (tabSelect)="selectTab($event)">
 
   @for (thematicTab of thematicTabs; track $index; let first = $first) {
-  @if (thematicTab.active) {
-  <dsfr-tab [tabId]="thematicTab.name" [label]="thematicTab.label">
+    @if (thematicTab.active) {
+    <dsfr-tab [tabId]="thematicTab.name" [label]="thematicTab.label">
 
-    @if (first) {
-    <app-synthese></app-synthese>
-    } @else {
-    <app-thematic-view [thematic]="thematicTab"></app-thematic-view>
+      @if (first) {
+      <app-synthese></app-synthese>
+      } @else {
+      <app-thematic-view [thematic]="thematicTab"></app-thematic-view>
+      }
+
+    </dsfr-tab>
     }
-
-  </dsfr-tab>
-  }
   }
 
 </dsfr-tabs>

--- a/src/app/shared-thematic/components/thematic-tabs/thematic-tabs.component.ts
+++ b/src/app/shared-thematic/components/thematic-tabs/thematic-tabs.component.ts
@@ -92,7 +92,15 @@ export class ThematicTabsComponent implements OnInit {
     layer.flatview = false;
     layer.features = [];
     layer.features = this.responseFeatures.filter((feature) => {
-      return this.parseLayerFromTechnicalName(layer.technicalName) === feature.layer;
+      if(this.parseLayerFromTechnicalName(layer.technicalName) === feature.layer) {
+        if(layer.title === 'Coeurs de parcs nationaux' && feature.zone != 'Coeur') {
+          return false
+        } else if(layer.title === 'Zones d\'adhésion de parcs nationaux' && feature.zone != 'Adhesion') {
+          return false
+        }
+        return true
+      }
+      return false;
     });
     return layer;
   }
@@ -103,8 +111,13 @@ export class ThematicTabsComponent implements OnInit {
       const layer = features[i].layer;
       switch (layer) {
         case 'assiette_sup_s':
-          if (!this.mapContextService.getActiveThematicLayers().includes({ theme: 'monument_historique', name: "assiette_sup_s" })) {
-            this.mapContextService.getActiveThematicLayers().push({ theme: 'monument_historique', name: "assiette_sup_s" });
+          if (!this.mapContextService.getActiveThematicLayers().includes({ theme: 'patrimoine', name: "assiette_sup_s" })) {
+            this.mapContextService.getActiveThematicLayers().push({ theme: 'patrimoine', name: "assiette_sup_s" });
+          }
+          break;
+        case 'prescription_surf':
+          if (!this.mapContextService.getActiveThematicLayers().includes({ theme: 'patrimoine', name: "prescription_surf" })) {
+            this.mapContextService.getActiveThematicLayers().push({ theme: 'patrimoine', name: "prescription_surf" });
           }
           break;
         default:

--- a/src/app/shared-thematic/components/thematic-view/thematic-view.component.ts
+++ b/src/app/shared-thematic/components/thematic-view/thematic-view.component.ts
@@ -13,6 +13,7 @@ export class ThematicViewComponent implements OnInit {
 
   constructor() { }
 
-  ngOnInit(): void { }
+  ngOnInit(): void { 
+  }
 
 }

--- a/src/app/shared-thematic/models/map-thematic-layers.enum.ts
+++ b/src/app/shared-thematic/models/map-thematic-layers.enum.ts
@@ -55,7 +55,7 @@ export const MAP_BIODIVERISTE_LAYER_GROUP = new LayerGroup({
       })
     }),
     new TileLayer({
-      properties: THEMATIC_LIST.find((g) => g.name === 'biodiversite')?.layers?.find((l) => l.technicalName === 'PROTECTEDAREAS.MNHN.CDL.PARCELS:cdl'),
+      properties: THEMATIC_LIST.find((g) => g.name === 'biodiversite')?.layers?.find((l) => l.technicalName === 'PROTECTEDAREAS.PNR:pnr'),
       extent: [
         -20037508.342789244,
         -44927335.42709704,
@@ -298,7 +298,7 @@ export const MAP_BIODIVERISTE_LAYER_GROUP = new LayerGroup({
       })
     }),
     new TileLayer({
-      properties: THEMATIC_LIST.find((g) => g.name === 'biodiversite')?.layers?.find((l) => l.technicalName === 'PROTECTEDAREAS.PN:pn'),
+      properties: THEMATIC_LIST.find((g) => g.name === 'biodiversite')?.layers?.find((l) => l.technicalName === 'PROTECTEDAREAS.PN:pn' && l.title === 'Coeurs de parcs nationaux'),
       extent: [
         -20037508.342789244,
         -44927335.42709704,
@@ -315,7 +315,31 @@ export const MAP_BIODIVERISTE_LAYER_GROUP = new LayerGroup({
         params: {
           'LAYERS': 'PROTECTEDAREAS.PN',
           'FORMAT': 'image/png',
-          'VERSION': '1.3.0'
+          'VERSION': '1.3.0',
+          'cql_filter': "zone = 'Coeur'"
+        },
+      })
+    }),
+    new TileLayer({
+      properties: THEMATIC_LIST.find((g) => g.name === 'biodiversite')?.layers?.find((l) => l.technicalName === 'PROTECTEDAREAS.PN:pn' && l.title === 'Zones d\'adhésion de parcs nationaux'),
+      extent: [
+        -20037508.342789244,
+        -44927335.42709704,
+        20037508.342789244,
+        44927335.42709663
+      ],
+      minResolution: 0,
+      maxResolution: 156543.03392804097,
+      source: new TileWMS({
+        url: 'https://data.geopf.fr/wms-r/ows?',
+        projection: 'EPSG:3857',
+        attributions: [],
+        crossOrigin: 'anonymous',
+        params: {
+          'LAYERS': 'PROTECTEDAREAS.PN',
+          'FORMAT': 'image/png',
+          'VERSION': '1.3.0',
+          'cql_filter': "zone = 'Adhesion'"
         },
       })
     }),

--- a/src/app/shared-thematic/models/thematic-list.enum.ts
+++ b/src/app/shared-thematic/models/thematic-list.enum.ts
@@ -66,7 +66,11 @@ export const THEMATIC_LIST = [
         group: 'biodiversite',
         technicalName: 'PROTECTEDAREAS.APG:apg'
       }, {
-        title: 'Parcs Nationaux',
+        title: 'Coeurs de parcs nationaux',
+        group: 'biodiversite',
+        technicalName: 'PROTECTEDAREAS.PN:pn'
+      }, {
+        title: 'Zones d\'adhésion de parcs nationaux',
         group: 'biodiversite',
         technicalName: 'PROTECTEDAREAS.PN:pn'
       }, {

--- a/src/app/shared-thematic/services/fiche-info-feature.service.ts
+++ b/src/app/shared-thematic/services/fiche-info-feature.service.ts
@@ -48,8 +48,7 @@ export class ThematicFeatureService {
       return this.geoplateformeWfsService.getFeatures(request).pipe(
         map((response) => {
           const features = response.features || [];
-          return features.map((feature: any) => this.parseFeature(feature))
-            .filter((feature: any) => this.filterFeature(feature));
+          return features.map((feature: any) => this.parseFeature(feature));
         })
       )
     });
@@ -77,6 +76,14 @@ export class ThematicFeatureService {
       request.filterByAttribute('typeass', 'Périmètre des abords');
     }
 
+    if(layer.title === 'Coeurs de parcs nationaux') {
+      request.filterByAttribute('zone', 'Coeur');
+    }
+
+    if(layer.title === 'Zones d\'adhésion de parcs nationaux') {
+      request.filterByAttribute('zone', 'Adhesion');
+    }
+
     if(layer.title === 'Espaces boisés classés') {
       request.filterByAttribute('typepsc', '01');
       request.filterByAttributeInValues('stypepsc', ['00', '01', '02', '03']);
@@ -96,8 +103,9 @@ export class ThematicFeatureService {
     const layer = this.parseLayerFromId(id);
     const properties = feature.properties;
     let link;
+    let zone = properties['zone'] ||'';
     if (properties['partition'] && properties['gpu_doc_id'] && properties['fichier'] || properties['nomfic']) {
-      let fichier = properties['ficier']?properties['ficier']:properties['nomfic'];
+      let fichier = properties['fichier']?properties['fichier']:properties['nomfic'];
       link = `${environment.geoportailUrbanismeDocumentsUrl}/${properties['partition']}/${properties['gpu_doc_id']}/${fichier}`;
     } else {
       link = properties.url;
@@ -107,21 +115,10 @@ export class ThematicFeatureService {
       id: id,
       layer: layer,
       name: name,
-      link: link
+      link: link,
+      zone: zone
     });
     return newFeature;
-  }
-
-  /**
-   * Cas particuliers selon les couches, pour les AC1 'Monuments historique' on ne garde que les abords
-   * @param feature 
-   * @returns boolean
-   */
-  private filterFeature(feature: any): boolean {
-    if (feature.suptype === 'ac1' && feature.typeass !== 'Périmètre des abords') {
-      return false;
-    }
-    return true;
   }
 
 


### PR DESCRIPTION
…ion des couches / feat(shared-thematic) : séparation de 'parcs nationaux' en deux couches 'Coeurs de parcs nationaux' et 'Zone d'adhésion' / supression de la fonction 'filterFeature' dans 'fiche-info-feature-service' car le filtrage est fait dans la requête avec les cql filters 

Au vue du [fichier de texte des règlementations](https://ignf.sharepoint.com/:x:/r/sites/FORESP/_layouts/15/Doc2.aspx?action=edit&sourcedoc=%7B0be12e65-eda6-4add-b5fd-cf138485cc52%7D&wdOrigin=TEAMS-MAGLEV.teamsSdk_ns.rwc&wdExp=TEAMS-TREATMENT&wdhostclicktime=1733303103870&web=1), j'ai séparé la couche "Parcs nationaux" en deux couches distinctes ("Coeurs" et "Zone d'adhésion") via requête avec filtre sur l'attribut "zone".

À noter que dans le fichier, il y a une distinction entre monuments historiques classés et monuments historiques inscrits. Hors, je ne vois pas de moyen de faire cette distinction avec les données que nous interrogeons. De plus, il avait été dit en réunion que seul le périmètre de protection des abords nous intéressait, ce qui n'est pas cohérent avec le fichier.

Cette PR traite l'[issue 24](https://github.com/IGNF/geoportail-environnement.beta.gouv.fr/issues/24) mais je ne m'en sors pas avec l'[issue 36](https://github.com/IGNF/geoportail-environnement.beta.gouv.fr/issues/36) associée. 
J'ai l'impression qu'on envoie bien les bonnes informations mais que les onglets ne s'affichent pas correctement et je ne comprends pas pourquoi.