### PR TITLE
fix(#40): Configuration pour la rechercher uniquement sur les adresse…

### DIFF
--- a/src/app/shared-map/components/geolocalise-form/geolocalise-form.component.ts
+++ b/src/app/shared-map/components/geolocalise-form/geolocalise-form.component.ts
@@ -40,6 +40,7 @@ export class GeolocaliseFormComponent implements OnInit {
     const map = this.mapContextService.getMap();
     if (map) {
       const searchControl = new SearchGeoportail({
+        type: 'StreetAddress', //Par defaut StreetAddress,PositionOfInterest
         target: 'location',
         maxItems: 3,
         className: 'fr-input-wrap fr-input-wrap--addon'


### PR DESCRIPTION
Modification de la configuration de la classe SearchGeoportail, pour uniquement récupère les adresses de rue et non les adresse de rue et les lieu d’intérêt.